### PR TITLE
Fix iterated scale

### DIFF
--- a/StableDiffusionGui/Ui/MainUi.cs
+++ b/StableDiffusionGui/Ui/MainUi.cs
@@ -93,16 +93,27 @@ namespace StableDiffusionGui.Ui
                 float valTo = splitMinMax[1].Trim().GetFloat();
                 float step = Math.Abs(customScalesText.Split(':').Last().GetFloat());
                 
-                if (valFrom > valTo) 
-                    (valFrom, valTo) = (valTo, valFrom);
+                int stepCount = 1 + (int)((valTo - valFrom) / step);
+                if (stepCount < 0)
+                {
+                    // align signs
+                    stepCount *= -1;
+                    step *= -1;
+                }
 
                 return new List<float>(
-                    from x in Enumerable.Range(0, 1 + (int)((valTo - valFrom) / step))
+                    from x in Enumerable.Range(0,stepCount)
                     select valFrom + x * step);
             }
             List<float> scales = new List<float> { CurrentScale };
-            scales.AddRange(customScalesText.Replace(" ", "").Split(",").Select(x => x.GetFloat()));
-            
+            foreach (string s in customScalesText.Split(","))
+            {
+                float f = 0;
+                if (float.TryParse(s, out f))
+                {
+                    scales.Add(f);
+                }
+            }
             return scales;
         }
 

--- a/StableDiffusionGui/Ui/MainUi.cs
+++ b/StableDiffusionGui/Ui/MainUi.cs
@@ -93,13 +93,14 @@ namespace StableDiffusionGui.Ui
                 float valTo = splitMinMax[1].Trim().GetFloat();
                 float step = Math.Abs(customScalesText.Split(':').Last().GetFloat());
                 
-                int stepCount = 1 + (int)((valTo - valFrom) / step);
+                int stepCount = (int)((valTo - valFrom) / step);
                 if (stepCount < 0)
                 {
                     // align signs
                     stepCount *= -1;
                     step *= -1;
                 }
+                stepCount += 1;  // include both endpoints
 
                 return new List<float>(
                     from x in Enumerable.Range(0,stepCount)
@@ -127,13 +128,15 @@ namespace StableDiffusionGui.Ui
                 float valTo = splitMinMax[1].Trim().GetFloat();
                 float step = customStrengthsText.Split(':').Last().GetFloat();
                 
-                int stepCount = 1 + (int)((valTo - valFrom) / step);
+                int stepCount = (int)((valTo - valFrom) / step);
                 if (stepCount < 0)
                 {
                     // align signs
                     stepCount *= -1;
                     step *= -1;
                 }
+
+                stepCount += 1; // include both endpoints
 
                 return new List<float>(
                     from x in Enumerable.Range(0, stepCount)

--- a/StableDiffusionGui/Ui/MainUi.cs
+++ b/StableDiffusionGui/Ui/MainUi.cs
@@ -126,14 +126,17 @@ namespace StableDiffusionGui.Ui
                 float valFrom = splitMinMax[0].GetFloat();
                 float valTo = splitMinMax[1].Trim().GetFloat();
                 float step = customStrengthsText.Split(':').Last().GetFloat();
-
-                List<float> incrementStrengths = new List<float>();
-
-                if (valFrom > valTo) 
-                    (valFrom, valTo) = (valTo, valFrom);
+                
+                int stepCount = 1 + (int)((valTo - valFrom) / step);
+                if (stepCount < 0)
+                {
+                    // align signs
+                    stepCount *= -1;
+                    step *= -1;
+                }
 
                 return new List<float>(
-                    from x in Enumerable.Range(0, 1 + (int)((valTo - valFrom) / step))
+                    from x in Enumerable.Range(0, stepCount)
                     select 1f - ( valFrom + x * step));
             } 
             


### PR DESCRIPTION
In my previous pull request, I rewrote GetScales and GetInitStrengths in a way that causes their "iteration syntax" mode to always go from the low value to the high value, therefore always using the lower bound if the increment isn't divisible by the range. This fixes it to always go in the specified direction (while still preventing accumulation of rounding error, and always counting in the correct direction).