### PR TITLE
Fix post proc loop

### DIFF
--- a/StableDiffusionGui/Main/PostProcess.cs
+++ b/StableDiffusionGui/Main/PostProcess.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Management.Automation;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -22,50 +23,45 @@ namespace StableDiffusionGui.Main
         {
             await Task.Delay(1000);
             outImgs = new List<string>();
+            DateTime exitTime = DateTime.MaxValue;
+            bool procRunning = true;
+            int totalImages = 0;
 
             while (true)
             {
                 try
                 {
                     var files = IoUtils.GetFileInfosSorted(imagesDir, false, "*.png");
+                    // Consider only files that were part of this run
+                    var images = files.Where(x => x.CreationTime > TextToImage.CurrentTask.StartTime).OrderBy(x => x.CreationTime).ToList();
 
-                    bool procRunning = TextToImage.CurrentTask.Processes.Where(x => x != null && !x.HasExited).Any();
-
-                    if (!procRunning && !files.Any())
+                    if (procRunning && !TextToImage.CurrentTask.Processes.Any(x => x != null && !x.HasExited))
+                    {
+                        // Last process just quit.
+                        Logger.Log("PostProcLoop observes all processes quit.", true);
+                        procRunning = false;
+                        exitTime = DateTime.Now;
+                    }
+                    
+                    // If there is no work to do, nothing is running, and the file system has had time to settle down, halt.
+                    if (!procRunning && !files.Any() && DateTime.Now - exitTime > TimeSpan.FromMilliseconds(500))
                         break;
-
-                    var images = files.Where(x => x.CreationTime > TextToImage.CurrentTask.StartTime).OrderBy(x => x.CreationTime).ToList(); // Find images and sort by date, newest to oldest
+                    
                     images = images.Where(x => (DateTime.Now - x.LastWriteTime).TotalMilliseconds > 500).ToList();
 
                     bool sub = TextToImage.CurrentTask.SubfoldersPerPrompt;
-                    Dictionary<string, string> imageDirMap = new Dictionary<string, string>();
-
-                    if (sub)
-                    {
-                        foreach (var img in images)
-                        {
-                            var imgTimeSinceLastWrite = DateTime.Now - img.LastWriteTime;
-                            string prompt = IoUtils.GetImageMetadata(img.FullName).Prompt;
-                            int pathBudget = 255 - img.Directory.FullName.Length - 65;
-                            string unixTimestamp = ((long)(DateTime.Now - new DateTime(1970, 1, 1)).TotalMilliseconds).ToString();
-                            string dirName = string.IsNullOrWhiteSpace(prompt) ? $"unknown_prompt_{unixTimestamp}" : FormatUtils.SanitizePromptFilename(prompt, pathBudget);
-                            imageDirMap[img.FullName] = Directory.CreateDirectory(Path.Combine(TextToImage.CurrentTask.OutPath, dirName)).FullName;
-                        }
-                    }
 
                     List<string> renamedImgPaths = new List<string>();
-
-                    for (int i = 0; i < images.Count; i++)
+                    foreach (FileInfo img in images)
                     {
                         try
                         {
-                            var img = images[i];
-                            string number = $"-{(TextToImage.CurrentTask.ImgCount).ToString().PadLeft(TextToImage.CurrentTask.TargetImgCount.ToString().Length, '0')}";
-
+                            string number = $"-{(totalImages+1).ToString().PadLeft(TextToImage.CurrentTask.TargetImgCount.ToString().Length, '0')}";
                             bool inclPrompt = !sub && Config.GetBool("checkboxPromptInFilename");
-                            string renamedPath = FormatUtils.GetExportFilename(img.FullName, sub ? imageDirMap[img.FullName] : imagesDir, number, "png", _maxPathLength, inclPrompt, true, true, true);
+                            string renamedPath = FormatUtils.GetExportFilename(img.FullName, DirForImage(img, imagesDir, sub), number, "png", _maxPathLength, inclPrompt, true, true, true);
                             img.MoveTo(renamedPath);
                             renamedImgPaths.Add(renamedPath);
+                            totalImages++;
                         }
                         catch(Exception ex)
                         {
@@ -91,5 +87,19 @@ namespace StableDiffusionGui.Main
             Logger.Log("PostProcLoop end.", true);
         }
 
+        private static string DirForImage(FileInfo img, string imagesDir, bool subfoldersPerPrompt)
+        {
+            if (!subfoldersPerPrompt)
+            {
+                return imagesDir;
+            }
+            string prompt = IoUtils.GetImageMetadata(img.FullName).Prompt;
+            int pathBudget = 255 - img.Directory.FullName.Length - 65;
+            string unixTimestamp = ((long)(DateTime.Now - new DateTime(1970, 1, 1)).TotalMilliseconds).ToString();
+            string dirName = string.IsNullOrWhiteSpace(prompt)
+                ? $"unknown_prompt_{unixTimestamp}"
+                : FormatUtils.SanitizePromptFilename(prompt, pathBudget);
+            return Directory.CreateDirectory(Path.Combine(imagesDir, dirName)).FullName;
+        }
     }
 }

--- a/StableDiffusionGui/Main/PostProcess.cs
+++ b/StableDiffusionGui/Main/PostProcess.cs
@@ -58,7 +58,7 @@ namespace StableDiffusionGui.Main
                         {
                             string number = $"-{(totalImages+1).ToString().PadLeft(TextToImage.CurrentTask.TargetImgCount.ToString().Length, '0')}";
                             bool inclPrompt = !sub && Config.GetBool("checkboxPromptInFilename");
-                            string renamedPath = FormatUtils.GetExportFilename(img.FullName, DirForImage(img, imagesDir, sub), number, "png", _maxPathLength, inclPrompt, true, true, true);
+                            string renamedPath = FormatUtils.GetExportFilename(img.FullName, DirForImage(img, sub), number, "png", _maxPathLength, inclPrompt, true, true, true);
                             img.MoveTo(renamedPath);
                             renamedImgPaths.Add(renamedPath);
                             totalImages++;
@@ -87,11 +87,11 @@ namespace StableDiffusionGui.Main
             Logger.Log("PostProcLoop end.", true);
         }
 
-        private static string DirForImage(FileInfo img, string imagesDir, bool subfoldersPerPrompt)
+        private static string DirForImage(FileInfo img, bool subfoldersPerPrompt)
         {
             if (!subfoldersPerPrompt)
             {
-                return imagesDir;
+                return TextToImage.CurrentTask.OutPath;
             }
             string prompt = IoUtils.GetImageMetadata(img.FullName).Prompt;
             int pathBudget = 255 - img.Directory.FullName.Length - 65;
@@ -99,7 +99,7 @@ namespace StableDiffusionGui.Main
             string dirName = string.IsNullOrWhiteSpace(prompt)
                 ? $"unknown_prompt_{unixTimestamp}"
                 : FormatUtils.SanitizePromptFilename(prompt, pathBudget);
-            return Directory.CreateDirectory(Path.Combine(imagesDir, dirName)).FullName;
+            return Directory.CreateDirectory(Path.Combine(TextToImage.CurrentTask.OutPath, dirName)).FullName;
         }
     }
 }


### PR DESCRIPTION
In https://github.com/n00mkrad/text2image-gui/commit/ef12f60fbad02089d75047d17962d587840e0540, not using "subdirectory per prompt" results in renaming images constantly into their own directory because the wrong folder was used for renames that are not using "subdirectory per prompt" mode.

Additionally, if there are images in the input directory from before the run (there probably shouldn't be, but the code checks for it anyway), the post-processing loop will never terminate. 

This PR fixes both issues. It contains other assorted cleanups to this codepath, I did those as part of finding the bug; if the code is harder to follow in any way, let me know and I'll refactor it to something you find clearer.