### PR TITLE
Fix performance when generating long prompt lists

### DIFF
--- a/StableDiffusionGui/Main/TtiProcess.cs
+++ b/StableDiffusionGui/Main/TtiProcess.cs
@@ -158,14 +158,9 @@ namespace StableDiffusionGui.Main
             // 
             // float gfpganSetting = Config.GetFloat("sliderGfpgan");
             // string gfpgan = gfpganSetting > 0.01f ? $"-G {gfpganSetting.ToStringDot("0.00")}" : "";
-
-            foreach (string prompt in prompts)
-            {
-                promptFileContent += $"{prompt}\n";
-                TextToImage.CurrentTask.TargetImgCount += iterations;
-            }
-
-            File.WriteAllText(promptFilePath, promptFileContent);
+            
+            TextToImage.CurrentTask.TargetImgCount += iterations * prompts.Length;
+            File.WriteAllText(promptFilePath, String.Join("\n", prompts));
 
             Logger.Log($"Preparing to run Optimized Stable Diffusion - {iterations} Iterations, {steps} Steps, Scale {scale}, {res.Width}x{res.Height}, Starting Seed: {seed}");
 

--- a/StableDiffusionGui/Main/TtiProcess.cs
+++ b/StableDiffusionGui/Main/TtiProcess.cs
@@ -54,7 +54,7 @@ namespace StableDiffusionGui.Main
             long startSeed = seed;
 
             string promptFilePath = Path.Combine(Paths.GetSessionDataPath(), "prompts.txt");
-            string promptFileContent = "";
+            List<string> promptFileLines = new List<string>();
 
             string upscaling = "";
             int upscaleSetting = Config.GetInt("comboxUpscale");
@@ -77,7 +77,7 @@ namespace StableDiffusionGui.Main
                         {
                             bool initImgExists = File.Exists(initImg);
                             string init = initImgExists ? $"--init_img {initImg.Wrap()} --strength {strength.ToStringDot("0.0000")}" : "";
-                            promptFileContent += $"{prompt} {init} -n {1} -s {steps} -C {scale.ToStringDot()} -A {sampler} -W {res.Width} -H {res.Height} -S {seed} {upscaling} {gfpgan} {(seamless ? "--seamless" : "")}\n";
+                            promptFileLines.Add($"{prompt} {init} -n {1} -s {steps} -C {scale.ToStringDot()} -A {sampler} -W {res.Width} -H {res.Height} -S {seed} {upscaling} {gfpgan} {(seamless ? "--seamless" : "")}");
                             TextToImage.CurrentTask.TargetImgCount++;
 
                             if (!initImgExists)
@@ -92,7 +92,7 @@ namespace StableDiffusionGui.Main
                     seed = startSeed;
             }
 
-            File.WriteAllText(promptFilePath, promptFileContent);
+            File.WriteAllText(promptFilePath, String.Join("\n", promptFileLines));
 
             Logger.Log($"Preparing to run Stable Diffusion - {iterations} Iterations, {steps} Steps, Scales {(scales.Length < 4 ? string.Join(", ", scales.Select(x => x.ToStringDot())) : $"{scales.First()}->{scales.Last()}")}, {res.Width}x{res.Height}, Starting Seed: {startSeed}");
 


### PR DESCRIPTION
Iteratively appending a string in C# is quadratic, because the entire (growing) string is copied at every iteration (because strings are immutable). As a result, prompt generation becomes slow with long prompt lists (3 prompts x 5 scales x 10000 iterations resulted in a program freeze I wasn't willing to wait through). There are two common ways to fix this:

1. use a StringBuilder, which is mutable
2. store all the "string chunks" to a list, then use Join to stitch them together

This takes the second approach, since it's slightly more efficient.