### PR TITLE
Import prompt and settings from clipboard

### DIFF
--- a/StableDiffusionGui/MainForm.Designer.cs
+++ b/StableDiffusionGui/MainForm.Designer.cs
@@ -172,6 +172,7 @@ namespace StableDiffusionGui
             this.pictBoxInitImg = new System.Windows.Forms.PictureBox();
             this.tableLayoutPanelImgViewers = new System.Windows.Forms.TableLayoutPanel();
             this.panel1 = new System.Windows.Forms.Panel();
+            this.importPromptFromClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStripOutputImg.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.upDownSeed)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.upDownIterations)).BeginInit();
@@ -1390,10 +1391,11 @@ namespace StableDiffusionGui
             this.openCmdInPythonEnvironmentToolStripMenuItem,
             this.openModelMergeToolToolStripMenuItem,
             this.openModelPruningTrimmingToolToolStripMenuItem,
-            this.convertModelsToolStripMenuItem});
+            this.convertModelsToolStripMenuItem,
+            this.importPromptFromClipboardToolStripMenuItem});
             this.menuStripDevTools.Name = "menuStripDevTools";
             this.menuStripDevTools.ShowImageMargin = false;
-            this.menuStripDevTools.Size = new System.Drawing.Size(234, 114);
+            this.menuStripDevTools.Size = new System.Drawing.Size(234, 158);
             // 
             // openCliToolStripMenuItem
             // 
@@ -2230,6 +2232,13 @@ namespace StableDiffusionGui
             this.panel1.Size = new System.Drawing.Size(512, 512);
             this.panel1.TabIndex = 0;
             // 
+            // importPromptFromClipboardToolStripMenuItem
+            // 
+            this.importPromptFromClipboardToolStripMenuItem.Name = "importPromptFromClipboardToolStripMenuItem";
+            this.importPromptFromClipboardToolStripMenuItem.Size = new System.Drawing.Size(233, 22);
+            this.importPromptFromClipboardToolStripMenuItem.Text = "Import prompt from clipboard";
+            this.importPromptFromClipboardToolStripMenuItem.Click += new System.EventHandler(this.importPromptFromClipboardToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AllowDrop = true;
@@ -2474,6 +2483,7 @@ namespace StableDiffusionGui
         public System.Windows.Forms.TableLayoutPanel tableLayoutPanelImgViewers;
         private System.Windows.Forms.Label labelAspectRatio;
         private System.Windows.Forms.ToolStripMenuItem copySidebySideComparisonImageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem importPromptFromClipboardToolStripMenuItem;
     }
 }
 

--- a/StableDiffusionGui/MainForm.cs
+++ b/StableDiffusionGui/MainForm.cs
@@ -538,5 +538,18 @@ namespace StableDiffusionGui
         {
             OsUtils.SetClipboard(ImageViewer.GetCurrentImageComparison());
         }
+
+        private void importPromptFromClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!OsUtils.GetClipboard(out string text))
+            {
+                MessageBox.Show("Clipboard is empty");
+                return;
+            }
+
+            Data.TtiSettings tti = MiscUtils.PromptImporterUtils.Import(text);
+            FormParsing.LoadTtiSettingsIntoUi(tti);
+
+        }
     }
 }

--- a/StableDiffusionGui/MainForm.cs
+++ b/StableDiffusionGui/MainForm.cs
@@ -547,8 +547,9 @@ namespace StableDiffusionGui
                 return;
             }
 
-            Data.TtiSettings tti = MiscUtils.PromptImporterUtils.Import(text);
-            FormParsing.LoadTtiSettingsIntoUi(tti);
+            var current = FormParsing.GetCurrentTtiSettings();
+            Data.TtiSettings newTti = MiscUtils.PromptImporterUtils.Import(text, current);
+            FormParsing.LoadTtiSettingsIntoUi(newTti);
 
         }
     }

--- a/StableDiffusionGui/MiscUtils/PromptImporterUtils.cs
+++ b/StableDiffusionGui/MiscUtils/PromptImporterUtils.cs
@@ -1,0 +1,62 @@
+﻿using StableDiffusionGui.Data;
+using System;
+using System.Linq;
+
+namespace StableDiffusionGui.MiscUtils
+{
+    internal class PromptImporterUtils
+    {
+        internal static TtiSettings Import(string prompt)
+        {
+            if (prompt == null) return null;
+            // Format:
+            // 3 lines:
+            // [0] "Positibe Prompt words ..."
+            // [1] "Negative prompt: words words ..."
+            // [2] "Key1: value1, Key2: value2, ..."
+
+            // allows for prompts generated for either windows or linux
+            // and also facilitates the split
+            if (prompt.Contains('\r')) prompt = prompt.Replace("\r", "");
+
+            var lines = prompt.Split('\n');
+
+            var tti = new TtiSettings();
+            // there are aways a first line
+            tti.Prompts = new string[] { lines[0] };
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                if (!lines[i].Contains(':')) continue; // ignore lines without :
+
+                // Parse negative prompt
+                if (lines[i].StartsWith("Negative prompt:", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var negative = lines[i].Substring(lines[i].IndexOf(':') + 1);
+                    tti.NegativePrompt = negative;
+
+                    continue;
+                }
+                // parse configs
+                if (lines[i].Contains(',')) // contains ',' and ':'
+                {
+                    var pairs = lines[i].Split(',');
+                    foreach(var p in pairs)
+                    {
+                        if (!p.Contains(':')) continue;
+
+                        var kvp = p.Split(':');
+                        tti.Params[kvp[0]] = kvp[1];
+                    }
+                }
+            }
+
+            if (tti.Params.ContainsKey("Steps"))
+            {
+                tti.Iterations = int.Parse(tti.Params["Steps"]);
+            }
+
+            return tti;
+        }
+    }
+}

--- a/StableDiffusionGui/Os/OsUtils.cs
+++ b/StableDiffusionGui/Os/OsUtils.cs
@@ -292,6 +292,21 @@ namespace StableDiffusionGui.Os
                 return false;
             }
         }
+        public static bool GetClipboard(out string text)
+        {
+            text = null;
+            try
+            {
+                if (Clipboard.ContainsText()) return false;
+                text = Clipboard.GetText();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Error getting clipboard text: {ex.Message}");
+                return false;
+            }
+        }
 
         public static void SendCtrlC(int pid)
         {
@@ -369,7 +384,7 @@ namespace StableDiffusionGui.Os
             string output = await Task.Run(() => GetProcStdOut(p, true));
             list = output.SplitIntoLines().Where(l => !string.IsNullOrWhiteSpace(l)).ToList();
 
-            for(int i = 0; i < list.Count; i++)
+            for (int i = 0; i < list.Count; i++)
             {
                 if (list[i].Contains("#egg="))
                     list[i] = list[i].Split("#egg=")[1].Split("&subdirectory=")[0];

--- a/StableDiffusionGui/Os/OsUtils.cs
+++ b/StableDiffusionGui/Os/OsUtils.cs
@@ -297,7 +297,7 @@ namespace StableDiffusionGui.Os
             text = null;
             try
             {
-                if (Clipboard.ContainsText()) return false;
+                if (!Clipboard.ContainsText()) return false;
                 text = Clipboard.GetText();
                 return true;
             }

--- a/StableDiffusionGui/StableDiffusionGui.csproj
+++ b/StableDiffusionGui/StableDiffusionGui.csproj
@@ -323,6 +323,7 @@
     <Compile Include="MiscUtils\InputUtils.cs" />
     <Compile Include="MiscUtils\NmkdStopwatch.cs" />
     <Compile Include="MiscUtils\ParseUtils.cs" />
+    <Compile Include="MiscUtils\PromptImporterUtils.cs" />
     <Compile Include="MiscUtils\PromptWildcardUtils.cs" />
     <Compile Include="Os\GpuUtils.cs" />
     <Compile Include="Os\HwInfo.cs" />


### PR DESCRIPTION
A lot of places publishes their prompts in the same format
~~~
[Positive]
Negative Prompt: [negative]
[settings]
~~~

This small PR parses a prompt in the clipboard and updates the UI

I tried to keep all styles and structure

* I used `OsUtils.cs` to check for clipboard content
* I used `Data.TtiSettings` to transport and migrate the settings
* I used `FormParsing.LoadTtiSettingsIntoUi` to update the UI
* All "old" settings params will be preserved if no new value is present in the settings list

I did not know a good place to put the action, so I placed it inside the Dev menu as `Import prompt from clipboard`

If I miss anything, let me know
Thanks in advance